### PR TITLE
Fix: close #1 Serial port does not mount on MacOS

### DIFF
--- a/usb/usb_serial_ctrl_ep.v
+++ b/usb/usb_serial_ctrl_ep.v
@@ -254,7 +254,21 @@ module usb_serial_ctrl_ep #(
               rom_length  <= 'h43;
             end
 
+            3 : begin
+              // STRING
+              in_ep_stall <= 1;
+              rom_addr    <= 'h00;
+              rom_length  <= 'h00;
+            end
+
             6 : begin
+              // DEVICE_QUALIFIER
+              in_ep_stall <= 1;
+              rom_addr   <= 'h00;
+              rom_length <= 'h00;
+            end
+            
+            default : begin
               // DEVICE_QUALIFIER
               in_ep_stall <= 1;
               rom_addr   <= 'h00;


### PR DESCRIPTION
This change fixed the USB mounting of the serial endpoint for me. I haven't done much testing, but the loopback seems to be working ok on two Mojave instances (laptop and desktop).

Next up... I'm going to see if I can get it connected to the picosoc example.