### PR TITLE
Add FuseSoC support

### DIFF
--- a/usbserial.core
+++ b/usbserial.core
@@ -1,0 +1,76 @@
+CAPI=2:
+
+name : ::usbserial
+
+filesets:
+  rtl:
+    files:
+      - usb/edge_detect.v
+      - usb/serial.v
+      - usb/usb_fs_in_arb.v
+      - usb/usb_fs_in_pe.v
+      - usb/usb_fs_out_arb.v
+      - usb/usb_fs_out_pe.v
+      - usb/usb_fs_pe.v
+      - usb/usb_fs_rx.v
+      - usb/usb_fs_tx_mux.v
+      - usb/usb_fs_tx.v
+      - usb/usb_reset_det.v
+      - usb/usb_serial_ctrl_ep.v
+      - usb/usb_uart_bridge_ep.v
+      - usb/usb_uart_core.v
+    file_type : verilogSource
+
+  generic: {files: [usb/usb_uart.v     : {file_type : verilogSource}]}
+  ecp5 :   {files: [usb/usb_uart_ecp5.v: {file_type : verilogSource}]}
+  ice40:   {files: [usb/usb_uart_i40.v : {file_type : verilogSource}]}
+
+  tinyfpga_bx:
+    files:
+      - usbserial_tbx.v : {file_type : verilogSource}
+      - pins.pcf: {file_type : PCF}
+    depend: [fusesoc:utils:generators]
+
+targets:
+  default:
+    filesets: [rtl]
+
+  lint:
+    default_tool : verilator
+    description: Lint check core with Verilator
+    filesets: [rtl, generic]
+    tools:
+      verilator:
+        mode : lint-only
+    toplevel: usb_uart
+
+  synth:
+    default_tool: icestorm
+    description: Run synthesis for resource/timing analysis
+    filesets:
+      - rtl
+      - "tool_icestorm? (ice40)"
+      - "!tool_icestorm?   (generic)"
+    tools:
+      icestorm: {pnr : none}
+      vivado: {pnr : none}
+    toplevel: usb_uart
+
+  tinyfpga_bx:
+    default_tool: icestorm
+    description: Build for TinyFPGA BX
+    filesets: [rtl, ice40, tinyfpga_bx]
+    generate: [tinyfpga_bx_pll]
+    tools:
+      icestorm:
+        pnr: next
+        nextpnr_options: [--freq, 48, --lp8k, --opt-timing, --package, cm81]
+    toplevel: usbserial_tbx
+
+generate:
+  tinyfpga_bx_pll:
+    generator: icepll
+    parameters:
+      freq_in  : 16
+      freq_out : 48
+      module: true


### PR DESCRIPTION
To test this

1. Install [FuseSoC](https://github.com/olofk/fusesoc)
2. Create an empty workspace directory. All subsequent commands are run from this directory
3. Add usbserial as FuseSoC library either by pointing to an existing location on disk (`fusesoc library add usbserial /path/to/repo`) or the github repo (`fusesoc library add usbserial https://github.com/davidthings/tinyfpga_bx_usbserial`)
4. Run linting with Verilator `fusesoc run --target=lint usbserial`
5. Build for TinyFPGA BX `fusesoc run --target=tinyfpga_bx usbserial`
6. Run synthesis with yosys (default tool) `fusesoc run --target=synth usbserial`
7. Run synthesis with vivado `fusesoc run --target=synth --tool=vivado usbserial`
8. Show available targets `fusesoc core show usbserial`