### PR TITLE
Fix: Windows 10 not enumerating device

### DIFF
--- a/usb/usb_serial_ctrl_ep.v
+++ b/usb/usb_serial_ctrl_ep.v
@@ -103,9 +103,11 @@ module usb_serial_ctrl_ep #(
   reg [7:0] bytes_sent = 0;
   reg [6:0] rom_length = 0;
 
+  wire wLength_is_large = |wLength[15:7]; // 15-7 bits because rom_length is only 7 bits wide
+
   wire all_data_sent =
     (bytes_sent >= rom_length) ||
-    (bytes_sent >= wLength[7:0]); // save it from the full 16b
+    (!wLength_is_large && bytes_sent >= wLength[7:0]); // if the requested wLength is large, we only send rom_length bytes
 
   wire more_data_to_send =
     !all_data_sent;


### PR DESCRIPTION
Gracefully handle the Host requesting more than 127 bytes (7bit) of descriptor ROM by ignoring the length and just sending the entire descriptor.

Should resolve the following:
https://github.com/davidthings/tinyfpga_bx_usbserial/issues/10
https://discourse.tinyfpga.com/t/usb-communication/613

